### PR TITLE
[FIX] tyt_audit: Restrict editing of 'auditor_check' field to auditors

### DIFF
--- a/tyt_audit/models/audit_plan_schedule_line.py
+++ b/tyt_audit/models/audit_plan_schedule_line.py
@@ -28,4 +28,9 @@ class PlanGeneralScheduleLine(models.Model):
     # new field
     done = fields.Boolean(string="Realizado")
     auditor_check = fields.Boolean(string='Auditor')
+    can_edit_auditor_check = fields.Boolean('Can Edit Auditor', compute='_compute_can_edit_auditor_check')
     fixed_date_check = fields.Boolean(string='Fecha fija')
+
+    def _compute_can_edit_auditor_check(self):
+        for record in self:
+            record.can_edit_auditor_check = self.env.user.has_group('tyt_audit.group_audit_auditor')

--- a/tyt_audit/views/audit_plan_schedule_line.xml
+++ b/tyt_audit/views/audit_plan_schedule_line.xml
@@ -7,7 +7,8 @@
             <field name="arch" type="xml">
                 <tree editable="bottom" create="false">
                     <field name="scheduled_date"/>
-                    <field name="auditor_check" groups="tyt_audit.group_audit_auditor"/>
+                    <field name="can_edit_auditor_check" invisible="1"/>
+                    <field name="auditor_check" attrs="{'readonly': [('can_edit_auditor_check', '=', False)]}"/>
                     <field name="done" groups="!tyt_audit.group_audit_auditor"/>
                     <field name="fixed_date_check" groups="!tyt_audit.group_audit_auditor"/>
                     <!--<field name="name" string="Nombre de línea"/>-->


### PR DESCRIPTION
- Added computed field `can_edit_auditor_check` to determine if the current user belongs to the 'tyt_audit.group_audit_auditor' group.